### PR TITLE
chore: use swift-format at 0.50500.0 to support older xcode

### DIFF
--- a/.github/workflows/ios_workflow.yaml
+++ b/.github/workflows/ios_workflow.yaml
@@ -7,7 +7,7 @@ defaults:
     working-directory: ./counter_app_ios
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
       - uses: subosito/flutter-action@v2
@@ -30,9 +30,13 @@ jobs:
       - name: Install Dependencies
         run: pod install
 
-      - uses: ConorMacBride/install-package@v1
-        with:
-          brew: swift-format
+      - name: Install swift-format
+        run: |
+          set HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK
+          set HOMEBREW_NO_INSTALL_UPGRADE
+          # Version 0.50500.0
+          curl https://raw.githubusercontent.com/Homebrew/homebrew-core/4f0edc5d74cdfa84822102a4f69f70a39561dea5/Formula/swift-format.rb > swift-format.rb
+          brew install swift-format.rb
 
       - name: Swift lint
         run: swift format lint -r .


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

We need to use older version of the [swift-format formula](https://github.com/Homebrew/homebrew-core/blob/4f0edc5d74cdfa84822102a4f69f70a39561dea5/Formula/swift-format.rb)

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
