### PR TITLE
fix: ipod touch not to overflow

### DIFF
--- a/flutter_nps/packages/app_ui/lib/src/widgets/capture_score_selector.dart
+++ b/flutter_nps/packages/app_ui/lib/src/widgets/capture_score_selector.dart
@@ -16,18 +16,21 @@ class CaptureScoreSelector extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    return Row(
-      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-      children: List.generate(
-        maxScore,
-        (index) {
-          return ScoreButton(
-            index: index,
-            isSelected: selectedIndex == index,
-            selectedCallback: selectedCallback,
-            theme: theme,
-          );
-        },
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: List.generate(
+          maxScore,
+          (index) {
+            return ScoreButton(
+              index: index,
+              isSelected: selectedIndex == index,
+              selectedCallback: selectedCallback,
+              theme: theme,
+            );
+          },
+        ),
       ),
     );
   }


### PR DESCRIPTION
ipod touch not to overflow
<img width="300" alt="image" src="https://user-images.githubusercontent.com/17708132/164483844-86ea63a6-4a2e-4d97-89da-7f6b401f7b15.png">

## Description


## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
