### PR TITLE
fix unwanted split view on iPad

### DIFF
--- a/newsfeed_ios/newsfeedApp/ContentView.swift
+++ b/newsfeed_ios/newsfeedApp/ContentView.swift
@@ -28,6 +28,7 @@ struct ContentView: View {
           }
         }
     }
+    .navigationViewStyle(.stack)
   }
 }
 


### PR DESCRIPTION
## Description


When running on iPad, we got this unwanted split view. This is the default behavior for `List` under `NavigationView` for iPad. But we don't want this because we have no "details view" to split with. 
 
Before this change: 
<img src="https://user-images.githubusercontent.com/41930132/167045619-afb61e14-02e0-448d-bbf3-173e817893a9.png" height="200">  <img src="https://user-images.githubusercontent.com/41930132/167045655-83619772-7afa-4455-a568-51e870adeefb.png" height="200">


After this change: 
<img src="https://user-images.githubusercontent.com/41930132/167045846-24eb359d-7903-44c6-b6de-db1e977c1df0.png" height="200">


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
