### PR TITLE
Fix archive build by updating Java

### DIFF
--- a/.github/workflows/android_workflow.yaml
+++ b/.github/workflows/android_workflow.yaml
@@ -34,7 +34,7 @@ jobs:
         working-directory: flutter_nps
         run: flutter build aar
 
-      - name: Set up JDK 1.8
+      - name: Set up JDK
         uses: actions/setup-java@d854b6da19cdadd9a010605529e522c2393ebd38
         with:
           java-version: "17"

--- a/.github/workflows/android_workflow.yaml
+++ b/.github/workflows/android_workflow.yaml
@@ -37,6 +37,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@d854b6da19cdadd9a010605529e522c2393ebd38
         with:
+          distribution: "zulu"
           java-version: "17"
 
       - name: Change wrapper permissions

--- a/.github/workflows/archive_workflow.yaml
+++ b/.github/workflows/archive_workflow.yaml
@@ -8,9 +8,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
 
 # Declare default permissions as read only.
 permissions: read-all

--- a/.github/workflows/archive_workflow.yaml
+++ b/.github/workflows/archive_workflow.yaml
@@ -29,6 +29,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@d854b6da19cdadd9a010605529e522c2393ebd38
         with:
+          distribution: "zulu"
           java-version: "17"
 
       - name: Build Flutter AAR file

--- a/.github/workflows/archive_workflow.yaml
+++ b/.github/workflows/archive_workflow.yaml
@@ -8,6 +8,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 # Declare default permissions as read only.
 permissions: read-all
@@ -22,6 +25,11 @@ jobs:
         with:
           channel: "stable"
       - run: flutter --version
+
+      - name: Set up JDK
+        uses: actions/setup-java@d854b6da19cdadd9a010605529e522c2393ebd38
+        with:
+          java-version: "17"
 
       - name: Build Flutter AAR file
         working-directory: flutter_nps


### PR DESCRIPTION
Explicitly sets a Java version to match the Android job, as the archive build also needs Java.

Specifies a distribution as well, due to it being needed by newer versions of the setup-java action.