### PR TITLE
Fix `bootstrap.dart` and Android runtime errors

### DIFF
--- a/flutter_nps/lib/bootstrap.dart
+++ b/flutter_nps/lib/bootstrap.dart
@@ -24,4 +24,11 @@ Future<void> bootstrap(FutureOr<Widget> Function() builder) async {
   };
 
   Bloc.observer = AppBlocObserver();
+
+  await runZonedGuarded(
+    () async {
+      runApp(await builder());
+    },
+    (error, stackTrace) => log(error.toString(), stackTrace: stackTrace),
+  );
 }

--- a/flutter_nps/lib/capture/view/capture_end_page.dart
+++ b/flutter_nps/lib/capture/view/capture_end_page.dart
@@ -32,11 +32,11 @@ class CaptureEndView extends StatelessWidget {
             const SizedBox(height: Spacing.xl),
             Text(
               context.l10n.thankYou,
-              style: Theme.of(context).textTheme.headline5,
+              style: Theme.of(context).textTheme.headlineSmall,
             ),
             Text(
               context.l10n.feedbackSubmittedMessage,
-              style: Theme.of(context).textTheme.subtitle1,
+              style: Theme.of(context).textTheme.titleMedium,
             ),
             const SizedBox(height: Spacing.xxhuge),
           ],

--- a/flutter_nps/lib/capture/view/capture_page.dart
+++ b/flutter_nps/lib/capture/view/capture_page.dart
@@ -60,14 +60,14 @@ class CaptureView extends StatelessWidget {
                 const SizedBox(height: Spacing.xl),
                 Text(
                   context.l10n.captureTitle,
-                  style: theme.textTheme.headline5
+                  style: theme.textTheme.headlineSmall
                       ?.copyWith(fontWeight: FontWeight.bold),
                   textAlign: TextAlign.center,
                 ),
                 const SizedBox(height: Spacing.xxs),
                 Text(
                   context.l10n.captureMessage,
-                  style: theme.textTheme.subtitle1
+                  style: theme.textTheme.titleMedium
                       ?.copyWith(color: NpsColors.colorGrey2),
                 ),
                 const SizedBox(height: Spacing.xl),

--- a/flutter_nps/packages/app_ui/lib/src/theme/app_theme.dart
+++ b/flutter_nps/packages/app_ui/lib/src/theme/app_theme.dart
@@ -28,9 +28,9 @@ class AppTheme {
           ),
         ),
         textTheme: const TextTheme(
-          headline5: NpsStyles.headline5,
-          subtitle1: NpsStyles.subtitle1,
-          bodyText2: NpsStyles.link,
+          headlineSmall: NpsStyles.headline5,
+          titleMedium: NpsStyles.subtitle1,
+          bodyMedium: NpsStyles.link,
         ),
       );
 }

--- a/flutter_nps/packages/app_ui/lib/src/widgets/capture_score_selector.dart
+++ b/flutter_nps/packages/app_ui/lib/src/widgets/capture_score_selector.dart
@@ -69,7 +69,7 @@ class ScoreButton extends StatelessWidget {
           alignment: Alignment.center,
         ),
         child: AnimatedDefaultTextStyle(
-          style: theme.textTheme.subtitle1?.copyWith(
+          style: theme.textTheme.titleMedium?.copyWith(
                 color:
                     isSelected ? NpsColors.colorWhite : NpsColors.colorPrimary1,
               ) ??

--- a/newsfeed_android/app/src/main/java/com/example/newsfeed_android/MainActivity.kt
+++ b/newsfeed_android/app/src/main/java/com/example/newsfeed_android/MainActivity.kt
@@ -1,4 +1,5 @@
 package com.example.newsfeed_android
+
 import android.os.Bundle
 import android.view.Window
 import androidx.appcompat.app.AppCompatActivity
@@ -39,50 +40,52 @@ class MainActivity : AppCompatActivity() {
             val linearLayoutManager = binding.recyclerView.layoutManager as LinearLayoutManager?
             if (!isLoading) {
                 if (linearLayoutManager != null &&
-                    linearLayoutManager.findLastCompletelyVisibleItemPosition() == (rowsArrayList.size - 1)) {
+                    linearLayoutManager.findLastCompletelyVisibleItemPosition() == (rowsArrayList.size - 1)
+                ) {
                     isLoading = true
-                    loadMore()
+                    loadMore(binding.recyclerView)
                 }
             }
         })
         binding.recyclerView.addOnScrollListener(loadMoreCallback)
     }
 
-    private fun initAdapter( binding: ActivityMainBinding) {
+    private fun initAdapter(binding: ActivityMainBinding) {
         recyclerViewAdapter = RecyclerViewAdapter(rowsArrayList)
         binding.recyclerView.layoutManager = LinearLayoutManager(applicationContext)
         binding.recyclerView.adapter = recyclerViewAdapter
     }
 
-    private fun populateData(list: ArrayList<String> ) {
+    private fun populateData(list: ArrayList<String>) {
         for (i in 0..20) {
             list.add(ROW_ITEM_NAME)
         }
     }
 
-    private fun loadMore() {
-        if(rowsArrayList.size in 19..29){
+    private fun loadMore(recyclerView: RecyclerView) {
+        if (rowsArrayList.size in 19..29) {
             runFlutterNPS()
         }
         runBlocking {
             launch {
                 fakeRequest()
-                rowsArrayList.removeAt(rowsArrayList.size - 1)
-                val scrollPosition = rowsArrayList.size
-                recyclerViewAdapter?.notifyItemRemoved(scrollPosition)
+                recyclerView.post {
+                    rowsArrayList.removeAt(rowsArrayList.size - 1)
+                    val scrollPosition = rowsArrayList.size
+                    recyclerViewAdapter?.notifyItemRemoved(scrollPosition)
 
-                var currentSize = rowsArrayList.size
-                val nextLimit = currentSize + 10
-                while (currentSize - 1 < nextLimit) {
-                    rowsArrayList.add(ROW_ITEM_NAME)
-                    currentSize++
+                    var currentSize = rowsArrayList.size
+                    val nextLimit = currentSize + 10
+                    while (currentSize - 1 < nextLimit) {
+                        rowsArrayList.add(ROW_ITEM_NAME)
+                        currentSize++
+                    }
+                    isLoading = false
+                    recyclerViewAdapter?.notifyItemRangeInserted(nextLimit - 10, 10)
                 }
-                isLoading = false
-                recyclerViewAdapter?.notifyItemRangeInserted(nextLimit - 10,10)
             }
         }
     }
-
 
 
     private suspend fun fakeRequest(): Boolean {
@@ -112,7 +115,8 @@ class MainActivity : AppCompatActivity() {
             .put(FLUTTER_ENGINE_NAME, flutterEngine)
     }
 
-    internal class LoadMoreOnScrollListener(private var callback: () -> Unit) : RecyclerView.OnScrollListener() {
+    internal class LoadMoreOnScrollListener(private var callback: () -> Unit) :
+        RecyclerView.OnScrollListener() {
         override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
             super.onScrolled(recyclerView, dx, dy)
             callback()

--- a/newsfeed_android/build.gradle
+++ b/newsfeed_android/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = '1.6.20-M1'
+    ext.kotlin_version = '1.6.21'
     repositories {
         google()
         mavenCentral()
@@ -15,8 +15,8 @@ buildscript {
 
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:7.0.3"
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.20"
+        classpath 'com.android.tools.build:gradle:7.4.2'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.21'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/newsfeed_android/gradle/wrapper/gradle-wrapper.properties
+++ b/newsfeed_android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Feb 03 12:28:34 CET 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Description

- In the PR #170 the call to `runApp` was removed.
- This PR restores the call while keeping the new `Bloc.observer`.
- Also, the Android runtime errors have been removed following the ideas in #195.
- Fixes #193

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
