### PR TITLE
Move away from deprecated strong-mode analysis options

### DIFF
--- a/flutter_nps/packages/app_ui/analysis_options.yaml
+++ b/flutter_nps/packages/app_ui/analysis_options.yaml
@@ -1,9 +1,9 @@
 include: package:flutter_lints/flutter.yaml
 
 analyzer:
-  strong-mode:
-    implicit-casts: false
-    implicit-dynamic: false
+  language:
+    strict-casts: true
+    strict-inference: true
 
   errors:
     missing_required_param: error

--- a/flutter_nps/pubspec.yaml
+++ b/flutter_nps/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   flutter_bloc: ^8.1.1
   flutter_localizations:
     sdk: flutter
-  intl: ^0.17.0
+  intl: any
   nps_repository:
     path: packages/nps_repository
   platform_close:


### PR DESCRIPTION
I'm going through `flutter/` and other projects and removing references to the deprecated `strong-mode` options to ease the final removal of them.

This enables similar [analyzer language modes](https://dart.dev/guides/language/analysis-options#enabling-additional-type-checks) to replace them.

Issue reference: https://github.com/dart-lang/sdk/issues/50679